### PR TITLE
simplify CI cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: ""


### PR DESCRIPTION
This uses a new GitHub action https://github.com/marketplace/actions/cache-julia-artifacts-packages-and-registry made specifically for this purpose, see also https://discourse.julialang.org/t/recommendation-cache-julia-artifacts-in-ci-services/35484/8.
Xref trixi-framework/Trixi.jl#1027