### PR TITLE
Support RectilinearGrid files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReadVTK"
 uuid = "dc215faf-f008-4882-a9f7-a79a826fadc3"
 authors = ["Michael Schlottke-Lakemper <michael@sloede.com>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -69,16 +69,17 @@ Further example VTK files can be found in the
 [`ReadVTK_examples` repository](https://github.com/trixi-framework/ReadVTK_examples).
 
 ### What works
-* Reading in VTK XML files of type `UnstructuredGrid` or `ImageData`
+* Reading in VTK XML files of type `UnstructuredGrid`, `RectilinearGrid`,`ImageData`, or `PolyData`
 * Extracting cell or point data
 * Extracting point coordinates
 * Extracting information about cell types
 * Only for `ImageData` files: get origin, spacing, and extent information
+* Only for `RectilinearGrid` files: get 1D coordinate vectors 
 * Reading `PolyData` files containing vortices, lines, and/or polygons
 
 ### What does not work
 * Reading VTK files not stored in the VTK XML format
-* Reading VTK files of other type than `UnstructuredGrid`, `ImageData`, or `PolyData`
+* Reading VTK files of other type than `UnstructuredGrid`, `ImageData`, `RectilinearGrid` or `PolyData`
 * Multiblock files, PVD files
 * Different byte orders in file and host system
 * Probably reading from VTK files that were *not* created by [WriteVTK.jl](https://github.com/jipolanco/WriteVTK.jl) will fail, specifically since

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Further example VTK files can be found in the
 
 ### What does not work
 * Reading VTK files not stored in the VTK XML format
-* Reading VTK files of other type than `UnstructuredGrid`, `ImageData`, `RectilinearGrid` or `PolyData`
+* Reading VTK files of other type than what is listed under *What works* above
 * Multiblock files, PVD files
 * Different byte orders in file and host system
 * Probably reading from VTK files that were *not* created by [WriteVTK.jl](https://github.com/jipolanco/WriteVTK.jl) will fail, specifically since

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Further contributions to ReadVTK have been made by the following people:
 (Universidad de la República, Uruguay)
 * [Ondřej Kincl](https://www2.karlin.mff.cuni.cz/~kincl/)
 (Charles University, Czech Republic)
+* [Boris Kaus](https://www.geosciences.uni-mainz.de/geophysics-and-geodynamics/team/univ-prof-dr-boris-kaus/)
+  (Johannes-Gutenberg University Mainz, Germany)
 
 ## License and contributing
 ReadVTK is licensed under the MIT license (see [LICENSE.md](LICENSE.md)).

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -486,9 +486,9 @@ function get_data_reshaped(data_array::VTKDataArray{T,Ncomponents}; cell_data=fa
 end
 
 """
-  get\\_local\\_size(xml_file, file_type, cell_data=false)
+    get_local_size(xml_file, file_type, cell_data=false)
 
-Retrieve the local size of a structured grid (ImageData, RectilinearGrid). Note that this always returns 3 dimensions, even if the data is 1D or 2D. 
+Retrieve the local size of a structured grid (ImageData, RectilinearGrid). Note that this always returns three dimensions, even if the data is 1D or 2D. 
 """
 function get_local_size(xml_file, file_type, cell_data=false)
 

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -522,13 +522,11 @@ function get_points(vtk_file)
 end
 
 """
-  get_coordinates(vtk_file; x_string="x",y_string="y",z_string="z")
+    get_coordinates(vtk_file; x_string="x", y_string="y", z_string="z")
 
-Retrieve VTK coordinate vectors in each direction as 1D vectors for a RectilinearGrid file
+Retrieve VTK coordinate vectors in each direction as a tuple of 1D vectors for a RectilinearGrid file.
 
-The points are given as 1D vectors. Note that in VTK, points are always stored
-three-dimensional, even for 1D or 2D files, so you will always retrieve 3 vectors.
-The 
+Note that in VTK, points are always stored three-dimensional, even for 1D or 2D files, so you will always retrieve a tuple with three vectors.
 
 See also: [`get_cells`](@ref)
 """

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -113,7 +113,7 @@ function VTKFile(filename)
   end
 
   # Ensure matching file types
-  if !(file_type in ("UnstructuredGrid", "ImageData", "PolyData","RectilinearGrid"))
+  if !(file_type in ("UnstructuredGrid", "ImageData", "PolyData", "RectilinearGrid"))
     error("Unsupported file type: ", file_type)
   end
 

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -127,7 +127,7 @@ function VTKFile(filename)
            (byte_order == "BigEndian" && !is_little_endian))
 
   # Ensure matching header type
-  #@assert header_type == "UInt64"
+  @assert header_type == "UInt64"
 
   # Ensure supported compression type
   @assert in(compressor, ("", "vtkZLibDataCompressor"))

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -235,9 +235,9 @@ See also: [`VTKData`](@ref), [`get_cell_data`](@ref)
 get_point_data(vtk_file) = get_data_section(vtk_file, "PointData")
 
 """
-  get_coordinate_data(vtk_file)
+    get_coordinate_data(vtk_file)
 
-Retrieve a lightweight `VTKData` object with the coordinates data of the given VTK file.
+Retrieve a lightweight `VTKData` object with the coordinate data of the given VTK file.
 
 See also: [`VTKData`](@ref), [`get_point_data`](@ref),  [`get_cell_data`](@ref)
 """

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -543,7 +543,7 @@ function get_coordinates(vtk_file; x_string="x",y_string="y",z_string="z")
   y = get_data(coordinates[y_string])
   z = get_data(coordinates[z_string])
 
-  return  x,y,z
+  return  x, y, z
 end
 
 

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -532,10 +532,9 @@ The
 
 See also: [`get_cells`](@ref)
 """
-function get_coordinates(vtk_file; x_string="x",y_string="y",z_string="z")
-
+function get_coordinates(vtk_file; x_string="x", y_string="y", z_string="z")
   if vtk_file.file_type != "RectilinearGrid"
-      error("the file_type must be RectilinearGrid.")
+      error("The file type of the VTK file must be 'RectilinearGrid' (current: $(vtk_file.file_type)).")
   end
 
   coordinates = get_coordinate_data(vtk_file)

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -481,7 +481,6 @@ end
 Retrieve the local size of a structured grid (ImageData, RectilinearGrid). Note that this always returns three dimensions, even if the data is 1D or 2D. 
 """
 function get_local_size(xml_file, file_type, cell_data=false)
-
   root = LightXML.root(xml_file)
   dataset_element = root[file_type][1]
   whole_extent = parse.(Int, split(attribute(dataset_element, "WholeExtent", required=true), ' '))

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -460,7 +460,6 @@ Note that vectors or tensors will have their components stored in the first dime
 As there is no way to automatically tell from the VTK file format whether it is a tensor, the user has to reshape this manually.
 """
 function get_data_reshaped(data_array::VTKDataArray{T,N}; cell_data=false) where {T,N}
-
   data = get_data(data_array);
 
   # Retrieve size of grid

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -486,15 +486,14 @@ function get_local_size(xml_file, file_type, cell_data=false)
   dataset_element = root[file_type][1]
   whole_extent = parse.(Int, split(attribute(dataset_element, "WholeExtent", required=true), ' '))
 
-  N = whole_extent[2:2:end] - whole_extent[1:2:end-1] .+ 1
+  Nlocal_size = whole_extent[2:2:end] - whole_extent[1:2:end-1] .+ 1
 
   if cell_data
-    N = N .- 1
-    N[N.==0] .= 1
+    local_size = local_size .- 1
+    local_size[local_size .== 0] .= 1
   end
 
-
-  return N
+  return local_size
 end
 
 """

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -453,12 +453,11 @@ end
 
 
 """
-    get\\_data\\_reshaped(data_array::VTKDataArray; cell_data=false)
+    get_data_reshaped(data_array::VTKDataArray; cell_data=false)
 
-Retrieve actual data from a `VTKDataArray` and reshapes them as 1D, 2D or 3D arrays, in case we deal with structured grids.
+Retrieve actual data from a `VTKDataArray` and reshape it as 1D, 2D, or 3D arrays, in case we deal with structured grids.
 Note that vectors or tensors will have their components stored in the first dimension of the array. 
-As there is no way to automatically tell from the VTK file format whether it is a tensor, the user has to reshape this accordingly.
-
+As there is no way to automatically tell from the VTK file format whether it is a tensor, the user has to reshape this manually.
 """
 function get_data_reshaped(data_array::VTKDataArray{T,N}; cell_data=false) where {T,N}
 

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -472,17 +472,16 @@ function get_data_reshaped(data_array::VTKDataArray{T,Ncomponents}; cell_data=fa
   data = get_data(data_array);
 
   # Retrieve size of grid
-  N   = get_local_size(data_array.vtk_file.xml_file, data_array.vtk_file.file_type, cell_data)
+  local_size = get_local_size(data_array.vtk_file.xml_file, data_array.vtk_file.file_type, cell_data)
   
   # reshape 
-  if Ncomponents==1
-    data_reshape = reshape(data, N...)
+  if N == 1
+    data_reshaped = reshape(data, local_size...)
   else
-    data_reshape = reshape(data, Ncomponents, N...)
+    data_reshaped = reshape(data, N, local_size...)
   end
 
-  return data_reshape
- 
+  return data_reshaped
 end
 
 """

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -485,7 +485,7 @@ function get_local_size(xml_file, file_type, cell_data=false)
   dataset_element = root[file_type][1]
   whole_extent = parse.(Int, split(attribute(dataset_element, "WholeExtent", required=true), ' '))
 
-  Nlocal_size = whole_extent[2:2:end] - whole_extent[1:2:end-1] .+ 1
+  local_size = whole_extent[2:2:end] - whole_extent[1:2:end-1] .+ 1
 
   if cell_data
     local_size = local_size .- 1

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 

--- a/test/rectilinear.jl
+++ b/test/rectilinear.jl
@@ -1,7 +1,7 @@
 using StaticArrays: SVector, SMatrix
 
 const FloatType = Float32
-const vtk_filename_noext = joinpath(TEST_EXAMPLES_DIR,"rectilinear")
+const vtk_filename_noext = joinpath(TEST_EXAMPLES_DIR, "rectilinear")
 
 outfiles = String[]
 

--- a/test/rectilinear.jl
+++ b/test/rectilinear.jl
@@ -4,6 +4,8 @@ const FloatType = Float32
 const vtk_filename_noext = joinpath(TEST_EXAMPLES_DIR,"rectilinear")
 
 outfiles = String[]
+
+for compress in [true, false]
 for dim in 2:3
     # Define grid.
     if dim == 2
@@ -71,9 +73,9 @@ for dim in 2:3
     # Initialise new vtr file (rectilinear grid).
     local vtk
     if dim == 2
-        vtk = vtk_grid(vtk_filename_noext*"_$(dim)D", x, y; extent=ext)
+        vtk = vtk_grid(vtk_filename_noext*"_$(dim)D", x, y; extent=ext, compress = compress)
     elseif dim == 3
-        vtk = vtk_grid(vtk_filename_noext*"_$(dim)D", x, y, z; extent=ext)
+        vtk = vtk_grid(vtk_filename_noext*"_$(dim)D", x, y, z; extent=ext, compress = compress)
     end
 
     # Add data.
@@ -95,7 +97,7 @@ for dim in 2:3
     name = vtk_save(vtk)[1]
 
     # read the file back     
-    @testset "$name" begin
+    @testset "$name compress=$compress" begin
         vtk_read = VTKFile(name)
         @testset "coordinates" begin 
             # read coordinates
@@ -130,6 +132,7 @@ for dim in 2:3
 
     end
 
+end
 end
 
 

--- a/test/rectilinear.jl
+++ b/test/rectilinear.jl
@@ -6,12 +6,12 @@ const vtk_filename_noext = joinpath(TEST_EXAMPLES_DIR, "rectilinear")
 outfiles = String[]
 
 for compress in [true, false]
-for dim in 2:3
+  for dim in 2:3
     # Define grid.
     if dim == 2
-        Ni, Nj, Nk = 20, 30, 1
+      Ni, Nj, Nk = 20, 30, 1
     elseif dim == 3
-        Ni, Nj, Nk = 20, 30, 40
+      Ni, Nj, Nk = 20, 30, 40
     end
 
     x = zeros(FloatType, Ni)
@@ -33,22 +33,21 @@ for dim in 2:3
     ts = zeros(SMatrix{3, 3, FloatType, 9}, Ni, Nj, Nk)
 
     for k = 1:Nk, j = 1:Nj, i = 1:Ni
-        p[i, j, k] = i*i + k
-        q[i, j, k] = k*sqrt(j)
+      p[i, j, k] = i*i + k
+      q[i, j, k] = k*sqrt(j)  
+      vec[1, i, j, k] = i
+      vec[2, i, j, k] = j
+      vec[3, i, j, k] = k
+      vs[i, j, k] = (i, j, k)  
 
-        vec[1, i, j, k] = i
-        vec[2, i, j, k] = j
-        vec[3, i, j, k] = k
-        vs[i, j, k] = (i, j, k)
-
-        A = similar(eltype(ts))
-        c = i - 2j + 3k
-        for I ∈ CartesianIndices(A)
-            v = (10 + I[1] - I[2]) * c
-            A[I] = v
-            tensor[I, i, j, k] = v
-        end
-        ts[i, j, k] = A
+      A = similar(eltype(ts))
+      c = i - 2j + 3k
+      for I ∈ CartesianIndices(A)
+        v = (10 + I[1] - I[2]) * c
+        A[I] = v
+        tensor[I, i, j, k] = v
+      end
+      ts[i, j, k] = A
     end
 
     # Create some scalar data at grid cells.
@@ -56,15 +55,15 @@ for dim in 2:3
     # formed between grid points.
     local cdata
     if dim == 2
-        cdata = zeros(FloatType, Ni-1, Nj-1)
-        for j = 1:Nj-1, i = 1:Ni-1
-            cdata[i, j] = 2i + 20 * sin(3*pi * (j-1) / (Nj-2))
-        end
+      cdata = zeros(FloatType, Ni-1, Nj-1)
+      for j = 1:Nj-1, i = 1:Ni-1
+        cdata[i, j] = 2i + 20 * sin(3*pi * (j-1) / (Nj-2))
+      end
     elseif dim == 3
-        cdata = zeros(FloatType, Ni-1, Nj-1, Nk-1)
-        for k = 1:Nk-1, j = 1:Nj-1, i = 1:Ni-1
-            cdata[i, j, k] = 2i + 3k * sin(3*pi * (j-1) / (Nj-2))
-        end
+      cdata = zeros(FloatType, Ni-1, Nj-1, Nk-1)
+      for k = 1:Nk-1, j = 1:Nj-1, i = 1:Ni-1
+        cdata[i, j, k] = 2i + 3k * sin(3*pi * (j-1) / (Nj-2))
+      end
     end
 
     # Test extents (this is optional!!)
@@ -73,9 +72,9 @@ for dim in 2:3
     # Initialise new vtr file (rectilinear grid).
     local vtk
     if dim == 2
-        vtk = vtk_grid(vtk_filename_noext*"_$(dim)D", x, y; extent=ext, compress = compress)
+      vtk = vtk_grid(vtk_filename_noext*"_$(dim)D", x, y; extent=ext, compress = compress)
     elseif dim == 3
-        vtk = vtk_grid(vtk_filename_noext*"_$(dim)D", x, y, z; extent=ext, compress = compress)
+      vtk = vtk_grid(vtk_filename_noext*"_$(dim)D", x, y, z; extent=ext, compress = compress)
     end
 
     # Add data.
@@ -98,41 +97,41 @@ for dim in 2:3
 
     # read the file back     
     @testset "$name compress=$compress" begin
-        vtk_read = VTKFile(name)
-        @testset "coordinates" begin 
-            # read coordinates
-            x_read, y_read, z_read = get_coordinates(vtk_read)
-            
-            @test x == x_read
-            @test y == y_read
-            if dim==3
-                @test z == z_read
-            end
+      vtk_read = VTKFile(name)
+      @testset "coordinates" begin 
+        # read coordinates
+        x_read, y_read, z_read = get_coordinates(vtk_read)
+        
+        @test x == x_read
+        @test y == y_read
+        if dim==3
+          @test z == z_read
         end
+      end
 
-        # point data 
-        @testset "point data" begin 
-            point_data = get_point_data(vtk_read);
-            p_read     = get_data_reshaped(point_data["p_values"])
-            @test p == p_read
+      # point data 
+      @testset "point data" begin 
+        point_data = get_point_data(vtk_read);
+        p_read     = get_data_reshaped(point_data["p_values"])
+        @test p == p_read    
+        q_read     = get_data_reshaped(point_data["q_values"])
+        @test q == q_read  
+        
+        myVector  = get_data_reshaped(point_data["myVector"])
+        @test vec == myVector
+      end
 
-            q_read     = get_data_reshaped(point_data["q_values"])
-            @test q == q_read
-
-            myVector  = get_data_reshaped(point_data["myVector"])
-            @test vec == myVector
-        end
-        @testset "cell data" begin 
-            cell_data = get_cell_data(vtk_read);
-            myCellData = get_data_reshaped(cell_data["myCellData"], cell_data=true)
-
-            @test sum(abs.(cdata-myCellData)) == 0
-
-        end
+      @testset "cell data" begin 
+        cell_data = get_cell_data(vtk_read);
+        
+        myCellData = get_data_reshaped(cell_data["myCellData"], cell_data=true)  
+        @test sum(abs.(cdata-myCellData)) == 0  
+      end
 
     end
-
+  
+  end
 end
-end
-
-
+  
+  
+  

--- a/test/rectilinear.jl
+++ b/test/rectilinear.jl
@@ -1,0 +1,135 @@
+using StaticArrays: SVector, SMatrix
+
+const FloatType = Float32
+const vtk_filename_noext = joinpath(TEST_EXAMPLES_DIR,"rectilinear")
+
+outfiles = String[]
+for dim in 2:3
+    # Define grid.
+    if dim == 2
+        Ni, Nj, Nk = 20, 30, 1
+    elseif dim == 3
+        Ni, Nj, Nk = 20, 30, 40
+    end
+
+    x = zeros(FloatType, Ni)
+    y = zeros(FloatType, Nj)
+    z = zeros(FloatType, Nk)
+
+    [x[i] = i*i/Ni/Ni for i = 1:Ni]
+    [y[j] = sqrt(j/Nj) for j = 1:Nj]
+    [z[k] = k/Nk for k = 1:Nk]
+
+    # Create some scalar and vector data.
+    p = zeros(FloatType, Ni, Nj, Nk)
+    q = zeros(FloatType, Ni, Nj, Nk)
+    vec = zeros(FloatType, 3, Ni, Nj, Nk)
+    vs = zeros(SVector{3, FloatType}, Ni, Nj, Nk)  # this is an alternative way of specifying a vector dataset
+
+    # 3×3 tensors
+    tensor = zeros(FloatType, 3, 3, Ni, Nj, Nk)
+    ts = zeros(SMatrix{3, 3, FloatType, 9}, Ni, Nj, Nk)
+
+    for k = 1:Nk, j = 1:Nj, i = 1:Ni
+        p[i, j, k] = i*i + k
+        q[i, j, k] = k*sqrt(j)
+
+        vec[1, i, j, k] = i
+        vec[2, i, j, k] = j
+        vec[3, i, j, k] = k
+        vs[i, j, k] = (i, j, k)
+
+        A = similar(eltype(ts))
+        c = i - 2j + 3k
+        for I ∈ CartesianIndices(A)
+            v = (10 + I[1] - I[2]) * c
+            A[I] = v
+            tensor[I, i, j, k] = v
+        end
+        ts[i, j, k] = A
+    end
+
+    # Create some scalar data at grid cells.
+    # Note that in structured grids, the cells are the hexahedra (3D) or quads (2D)
+    # formed between grid points.
+    local cdata
+    if dim == 2
+        cdata = zeros(FloatType, Ni-1, Nj-1)
+        for j = 1:Nj-1, i = 1:Ni-1
+            cdata[i, j] = 2i + 20 * sin(3*pi * (j-1) / (Nj-2))
+        end
+    elseif dim == 3
+        cdata = zeros(FloatType, Ni-1, Nj-1, Nk-1)
+        for k = 1:Nk-1, j = 1:Nj-1, i = 1:Ni-1
+            cdata[i, j, k] = 2i + 3k * sin(3*pi * (j-1) / (Nj-2))
+        end
+    end
+
+    # Test extents (this is optional!!)
+    ext = map(N -> (1:N) .+ 42, (Ni, Nj, Nk))
+
+    # Initialise new vtr file (rectilinear grid).
+    local vtk
+    if dim == 2
+        vtk = vtk_grid(vtk_filename_noext*"_$(dim)D", x, y; extent=ext)
+    elseif dim == 3
+        vtk = vtk_grid(vtk_filename_noext*"_$(dim)D", x, y, z; extent=ext)
+    end
+
+    # Add data.
+    vtk["p_values"] = p
+    vtk["q_values"] = q
+    
+    # Test passing the second optional argument.
+    @test_throws DimensionMismatch WriteVTK.num_components(
+        vec, vtk, VTKCellData())
+    vtk["myVector", VTKPointData()] = vec
+    vtk["mySVector", VTKPointData()] = vs
+    vtk["tensor"] = tensor
+    vtk["tensor.SMatrix"] = ts
+    vtk["myCellData"] = cdata
+
+    # Save and close vtk file.
+    append!(outfiles, vtk_save(vtk))
+
+    name = vtk_save(vtk)[1]
+
+    # read the file back     
+    @testset "$name" begin
+        vtk_read = VTKFile(name)
+        @testset "coordinates" begin 
+            # read coordinates
+            x_read, y_read, z_read = get_coordinates(vtk_read)
+            
+            @test x == x_read
+            @test y == y_read
+            if dim==3
+                @test z == z_read
+            end
+        end
+
+        # point data 
+        @testset "point data" begin 
+            point_data = get_point_data(vtk_read);
+            p_read     = get_data_reshaped(point_data["p_values"])
+            @test p == p_read
+
+            q_read     = get_data_reshaped(point_data["q_values"])
+            @test q == q_read
+
+            myVector  = get_data_reshaped(point_data["myVector"])
+            @test vec == myVector
+        end
+        @testset "cell data" begin 
+            cell_data = get_cell_data(vtk_read);
+            myCellData = get_data_reshaped(cell_data["myCellData"], cell_data=true)
+
+            @test sum(abs.(cdata-myCellData)) == 0
+
+        end
+
+    end
+
+end
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -214,7 +214,8 @@ mkpath(TEST_EXAMPLES_DIR)
       cell_data_reshaped = reshape(cell_data_raw, ((Nx-1), (Ny-1), (Nz-1)))
       cell_data_reshaped1 = get_data_reshaped(get_cell_data(vtk)[cell_data_name], cell_data=true)
       
-      @test cell_data_reshaped == cell_scalar_field 
+      @test cell_data_reshaped == cell_scalar_field
+      @test cell_data_reshaped1 == cell_scalar_field
     end
 
     @testset "get scalar point data" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,7 +223,8 @@ mkpath(TEST_EXAMPLES_DIR)
       point_data_reshaped = reshape(point_data_raw, (Nx, Ny, Nz))
       point_data_reshaped1 =  get_data_reshaped(get_point_data(vtk)[point_data_name])
       
-      @test point_data_reshaped == point_scalar_field == point_data_reshaped1
+      @test point_data_reshaped == point_scalar_field
+      @test point_data_reshaped1 == point_scalar_field
     end
 
     # generate random 2D data

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -212,15 +212,18 @@ mkpath(TEST_EXAMPLES_DIR)
     @testset "get scalar cell data" begin
       cell_data_raw = get_data(get_cell_data(vtk)[cell_data_name])
       cell_data_reshaped = reshape(cell_data_raw, ((Nx-1), (Ny-1), (Nz-1)))
-      @test cell_data_reshaped == cell_scalar_field
+      cell_data_reshaped1 = get_data_reshaped(get_cell_data(vtk)[cell_data_name], cell_data=true)
+      
+      @test cell_data_reshaped == cell_scalar_field 
     end
 
     @testset "get scalar point data" begin
       point_data_raw = get_data(get_point_data(vtk)[point_data_name])
       point_data_reshaped = reshape(point_data_raw, (Nx, Ny, Nz))
-      @test point_data_reshaped == point_scalar_field
+      point_data_reshaped1 =  get_data_reshaped(get_point_data(vtk)[point_data_name])
+      
+      @test point_data_reshaped == point_scalar_field == point_data_reshaped1
     end
-
 
     # generate random 2D data
     point_scalar_field = rand(Nx, Ny)
@@ -356,6 +359,10 @@ mkpath(TEST_EXAMPLES_DIR)
     end
 
   end 
+  
+  @testset "RectilinearGrid" begin
+    include("RectilinearGrid.jl")
+  end
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -361,7 +361,7 @@ mkpath(TEST_EXAMPLES_DIR)
   end 
   
   @testset "RectilinearGrid" begin
-    include("RectilinearGrid.jl")
+    include("rectilinear.jl")
   end
 
 end


### PR DESCRIPTION
This adds support for RectilinearGrid (`*.vtr`) files, and includes routines to retrieve 1D coordinate vectors. 
It also includes `get_data_reshaped` which reshapes the structured data in the appropriate formatfor `ImageData` and `RectilinearGrid`. 