### PR TITLE
Use latest Julia release for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       matrix:
         version:
           - '1.6'
+          - '1'
           # - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,7 @@ concurrency:
 jobs:
   test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
-    # We could also include the Julia version as in
-    # name: ${{ matrix.os }} - Julia ${{ matrix.version }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    # to be more specific. However, that requires us updating the required CI tests whenever we update Julia.
-    name: ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: ${{ matrix.os }} - Julia ${{ matrix.version }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
As suggested by @boriskaus, do not just test on Julia v1.6 but also on the latest released version (semver '1'). Let's keep v1.6 around for a while, as it helps to maintain a certain level of backward comparability.